### PR TITLE
[XGUARD-4901] update supervisor shift API to accept location

### DIFF
--- a/src/Http/Controllers/SupervisorShiftController.php
+++ b/src/Http/Controllers/SupervisorShiftController.php
@@ -16,7 +16,9 @@ class SupervisorShiftController extends Controller
         try {
             $shift = SupervisorShift::create([
                 SupervisorShift::USER_ID => $request->user_id,
-                SupervisorShift::START_TIME => $request->start_time
+                SupervisorShift::START_TIME => $request->start_time,
+                SupervisorShift::START_LAT => $request->start_lat,
+                SupervisorShift::START_LNG => $request->start_lng
             ]);
             return Response::make([SupervisorShift::ID => $shift->id], ResponseAlias::HTTP_CREATED);
         } catch (\Exception $e) {
@@ -30,7 +32,11 @@ class SupervisorShiftController extends Controller
     public function update(SupervisorShiftRequest $request): \Illuminate\Http\Response
     {
         $shift = SupervisorShift::find($request->id);
-        $shift->fill([SupervisorShift::END_TIME => $request->end_time,])->save();
+        $shift->fill([
+            SupervisorShift::END_TIME => $request->end_time,
+            SupervisorShift::END_LAT => $request->start_lat,
+            SupervisorShift::END_LNG => $request->start_lng
+        ])->save();
         $shift->refresh();
         return Response::make([SupervisorShift::ID => $shift->id], ResponseAlias::HTTP_OK);
     }

--- a/src/Http/Requests/SupervisorShiftRequest.php
+++ b/src/Http/Requests/SupervisorShiftRequest.php
@@ -16,7 +16,11 @@ class SupervisorShiftRequest extends BaseFormRequest
             SupervisorShift::ID => 'required_without:'.SupervisorShift::USER_ID. '|exists:Xguard\Coordinator\Models\SupervisorShift,id',
             SupervisorShift::USER_ID => 'required_without:'.SupervisorShift::ID.'|exists:App\Models\User,id',
             SupervisorShift::START_TIME => 'required_without:'.SupervisorShift::END_TIME.'|date',
+            SupervisorShift::START_LAT => 'required_with:'.SupervisorShift::START_TIME.'|numeric',
+            SupervisorShift::START_LNG => 'required_with:'.SupervisorShift::START_TIME.'|numeric',
             SupervisorShift::END_TIME => 'required_without:'.SupervisorShift::START_TIME.'|date',
+            SupervisorShift::END_LAT => 'required_with:'.SupervisorShift::END_TIME.'|numeric',
+            SupervisorShift::END_LNG => 'required_with:'.SupervisorShift::END_TIME.'|numeric',
         ];
     }
 

--- a/src/Models/SupervisorShift.php
+++ b/src/Models/SupervisorShift.php
@@ -20,6 +20,10 @@ class SupervisorShift extends Model
     const USER_ID = 'user_id';
     const START_TIME = 'start_time';
     const END_TIME = 'end_time';
+    const START_LAT = 'start_lat';
+    const START_LNG = 'start_lng';
+    const END_LAT = 'end_lat';
+    const END_LNG = 'end_lng';
     const DELETED = 'DELETED';
     const USER = 'USER';
 

--- a/src/database/migrations/2022_04_11_175600_add_location_columns_to_supervisor_shifts_table.php
+++ b/src/database/migrations/2022_04_11_175600_add_location_columns_to_supervisor_shifts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLocationColumnsToSupervisorShiftsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('sa_supervisor_shifts', function (Blueprint $table) {
+            $table->double('start_lat')->nullable()->after('end_time');;
+            $table->double('start_lng')->nullable()->after('end_time');;
+            $table->double('end_lat')->nullable()->after('end_time');;
+            $table->double('end_lng')->nullable()->after('end_time');;
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('sa_job_site_visits', function (Blueprint $table) {
+            $table->dropColumn('start_lat');
+            $table->dropColumn('start_lng');
+            $table->dropColumn('end_lat');
+            $table->dropColumn('end_lng');
+        });
+    }
+}

--- a/tests/Routes/SupervisorShiftRoutesTest.php
+++ b/tests/Routes/SupervisorShiftRoutesTest.php
@@ -33,6 +33,8 @@ class SupervisorShiftRoutesTest extends TestCase
         $data = [
             SupervisorShift::USER_ID => $user->id,
             SupervisorShift::START_TIME => $this->faker->date(),
+            SupervisorShift::START_LAT => $this->faker->latitude,
+            SupervisorShift::START_LNG => $this->faker->longitude,
         ];
         $response = $this->post($apiCall, $data);
         $count = count(SupervisorShift::all());
@@ -46,7 +48,9 @@ class SupervisorShiftRoutesTest extends TestCase
         $apiCall = route(self::COORDINATOR_UPDATE_SHIFT);
         $data = [
             SupervisorShift::ID => $supervisorShift->id,
-            SupervisorShift::END_TIME => $this->faker->date()
+            SupervisorShift::END_TIME => $this->faker->date(),
+            SupervisorShift::END_LAT => $this->faker->latitude,
+            SupervisorShift::END_LNG => $this->faker->longitude,
         ];
         $response = $this->patch($apiCall, $data);
         $response->assertOk();


### PR DESCRIPTION

### Description}

start and end lat/lng are accepted in supervisor shift api.

When posting into api/coordinator/shift we need:

- user_id
- start_time
- start_lat (numeric)
- start_lng (numeric)

When patching into api/coordinator/shift we need:

- id (of shift)
- end_time
- end_lat  (numeric)
- end_lng (numeric)



### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (adds functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Refactor (code changes that do **NOT** change functionality)
- [ ] Code Coverage (adds Unit Tests)

### Checklist:
Please check if your PR fulfills the following requirements:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Unit Tests for the changes have been added.
- [x] Contains **NO** breaking changes.
- [x] Associated with a JIRA issue.
